### PR TITLE
[TECH-4407] Prevent NPE crash

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -833,8 +833,9 @@ public class OneSignal {
 
       initDone = true;
       OneSignal.Log(LOG_LEVEL.VERBOSE, "OneSignal SDK initialization done.");
-
-      outcomeEventsController.sendSavedOutcomes();
+      if (outcomeEventsController != null) {
+         outcomeEventsController.sendSavedOutcomes();
+      }
 
       // Clean up any pending tasks that were queued up before initialization
       taskRemoteController.startPendingTasks();
@@ -949,7 +950,9 @@ public class OneSignal {
          logger.debug("Starting new session with appEntryState: " + getAppEntryState());
 
          OneSignalStateSynchronizer.setNewSession();
-         outcomeEventsController.cleanOutcomes();
+         if (outcomeEventsController != null) {
+            outcomeEventsController.cleanOutcomes();
+         }
          sessionManager.restartSessionIfNeeded(getAppEntryState());
          getInAppMessageController().resetSessionLaunchTime();
          setLastSessionTime(time.getCurrentTimeMillis());


### PR DESCRIPTION
Prevent NPE crash

[Firebase](https://console.firebase.google.com/u/0/project/media-b6ace/crashlytics/app/android:com.machipopo.media17/issues/6a7f35569979382306632bf3042abbbe?time=last-seven-days&sessionEventKey=61E6508000BC00012C1975D300FA88DF_1632859991144206650)

```Java
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'void com.onesignal.OSOutcomeEventsController.q()' on a null object reference
       at com.onesignal.OneSignal.init(OneSignal.java:837)
       at com.onesignal.OneSignal.setAppId(OneSignal.java:692)
       at com.onesignal.OneSignal.reassignDelayedInitParams(OneSignal.java:1136)
       at com.onesignal.OneSignal.onRemoteParamSet(OneSignal.java:844)
       at com.onesignal.OneSignal$6.complete(OneSignal.java:1077)
       at com.onesignal.OneSignalRemoteParams.processJson(OneSignalRemoteParams.java:206)
       at com.onesignal.OneSignalRemoteParams.access$100(OneSignalRemoteParams.java:12)
       at com.onesignal.OneSignalRemoteParams$1.onSuccess(OneSignalRemoteParams.java:151)
       at com.onesignal.OneSignalRestClient$5.run(OneSignalRestClient.java:283)
       at java.lang.Thread.run(Thread.java:761)
```
