### PR TITLE
[TECH-4492] Fix NPE Crashes

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/InAppMessageView.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/InAppMessageView.java
@@ -153,10 +153,12 @@ class InAppMessageView {
                 }
 
                 ViewGroup.LayoutParams layoutParams = webView.getLayoutParams();
-                layoutParams.height = pageHeight;
-                // We only need to update the WebView size since it's parent layouts are set to
-                //   WRAP_CONTENT to always match the height of the WebView. (Expect for fullscreen)
-                webView.setLayoutParams(layoutParams);
+                if (layoutParams != null) {
+                    layoutParams.height = pageHeight;
+                    // We only need to update the WebView size since it's parent layouts are set to
+                    //   WRAP_CONTENT to always match the height of the WebView. (Expect for fullscreen)
+                    webView.setLayoutParams(layoutParams);
+                }
 
                 // draggableRelativeLayout comes in null here sometimes, this is due to the IAM
                 //  not being ready to be shown yet

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSessionManager.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSSessionManager.java
@@ -166,7 +166,7 @@ public class OSSessionManager {
         logger.debug("OneSignal SessionManager attemptSessionUpgrade try UNATTRIBUTED to INDIRECT upgrade");
         // We will try to override the UNATTRIBUTED session with INDIRECT
         for (OSChannelTracker channelTracker : channelTrackersToReset) {
-            if (channelTracker.getInfluenceType().isUnattributed()) {
+            if (channelTracker.getInfluenceType() != null && channelTracker.getInfluenceType().isUnattributed()) {
                 JSONArray lastIds = channelTracker.getLastReceivedIds();
                 // There are new ids for attribution and the application was open again without resetting session
                 if (lastIds.length() > 0 && !entryAction.isAppClose()) {


### PR DESCRIPTION
Fix NPE Crashes
[Firebase](https://console.firebase.google.com/u/0/project/media-b6ace/crashlytics/app/android:com.machipopo.media17/issues/2cfd7239e027f261d21dba19da4e5286?time=last-seven-days&types=crash&sessionEventKey=61ED542400C6000142DEFE440764719D_1634834512765227291)
```Java
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'boolean com.onesignal.influence.domain.OSInfluenceType.h()' on a null object reference
       at com.onesignal.OSSessionManager.attemptSessionUpgrade(OSSessionManager.java:169)
       at com.onesignal.OSSessionManager.attemptSessionUpgrade(OSSessionManager.java:133)
       at com.onesignal.OneSignal.doSessionInit(OneSignal.java:961)
       at com.onesignal.OneSignal.onAppFocusLogic(OneSignal.java:1388)
       at com.onesignal.OneSignal.onAppFocus(OneSignal.java:1378)
       at com.onesignal.ActivityLifecycleHandler.handleFocus(ActivityLifecycleHandler.java:182)
       at com.onesignal.ActivityLifecycleHandler.onActivityResumed(ActivityLifecycleHandler.java:88)
       at com.onesignal.ActivityLifecycleListener.onActivityResumed(ActivityLifecycleListener.java:91)
       at android.app.Application.dispatchActivityResumed(Application.java:216)
       at android.app.Activity.onResume(Activity.java:1312)
       at androidx.fragment.app.FragmentActivity.onResume(FragmentActivity.java:433)
       at com.live17.core.logevent.generic.activity.GenericLogEventAppCompatActivity.onResume(GenericLogEventAppCompatActivity.kt:111)
       at com.machipopo.media17.base.ui.activity.BaseActivity.onResume(BaseActivity.kt:118)
       at com.machipopo.media17.activity.LiveStreamActivity.onResume(LiveStreamActivity.java:984)
       at android.app.Instrumentation.callActivityOnResume(Instrumentation.java:1355)
       at android.app.Activity.performResume(Activity.java:7079)
       at android.app.ActivityThread.performResumeActivity(ActivityThread.java:3625)
       at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:3690)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1648)
       at android.os.Handler.dispatchMessage(Handler.java:105)
       at android.os.Looper.loop(Looper.java:251)
       at android.app.ActivityThread.main(ActivityThread.java:6572)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:240)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:767)
```

[Firebase](https://console.firebase.google.com/u/0/project/media-b6ace/crashlytics/app/android:com.machipopo.media17/issues/2d27794960564061d9adc615fd7c362f?time=last-seven-days&types=crash&sessionEventKey=61ECE6A1002D0001589FC408CE531B87_1634713914133150421)
```Java
Caused by java.lang.NullPointerException: Attempt to write to field 'int android.view.ViewGroup$LayoutParams.height' on a null object reference
       at com.onesignal.InAppMessageView$1.run(InAppMessageView.java:156)
       at com.onesignal.OSUtils.runOnMainUIThread(OSUtils.java:473)
       at com.onesignal.InAppMessageView.updateHeight(InAppMessageView.java:145)
       at com.onesignal.WebViewManager.showMessageView(WebViewManager.java:413)
       at com.onesignal.WebViewManager.available(WebViewManager.java:385)
       at com.onesignal.ActivityLifecycleHandler.setCurActivity(ActivityLifecycleHandler.java:230)
       at com.onesignal.ActivityLifecycleHandler.onActivityResumed(ActivityLifecycleHandler.java:86)
       at com.onesignal.ActivityLifecycleListener.onActivityResumed(ActivityLifecycleListener.java:91)
       at android.app.Application.dispatchActivityResumed(Application.java:436)
       at android.app.Activity.dispatchActivityResumed(Activity.java:1405)
       at android.app.Activity.onResume(Activity.java:1931)
       at androidx.fragment.app.FragmentActivity.onResume(FragmentActivity.java:433)
       at com.live17.core.logevent.generic.activity.GenericLogEventAppCompatActivity.onResume(GenericLogEventAppCompatActivity.kt:111)
       at com.machipopo.media17.base.ui.activity.BaseActivity.onResume(BaseActivity.kt:118)
       at com.machipopo.media17.activity.LiveStreamActivity.onResume(LiveStreamActivity.java:984)
       at android.app.Instrumentation.callActivityOnResume(Instrumentation.java:1457)
       at android.app.Activity.performResume(Activity.java:8231)
       at android.app.ActivityThread.performResumeActivity(ActivityThread.java:4766)
       at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:4808)
       at android.app.servertransaction.ResumeActivityItem.execute(ResumeActivityItem.java:52)
       at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2223)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loop(Looper.java:223)
       at android.app.ActivityThread.main(ActivityThread.java:8240)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:979)
```