### PR TITLE
[TECH-4703] IllegalStateException when JobSchedulerImpl.schedule

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSBackgroundSync.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSBackgroundSync.java
@@ -139,7 +139,7 @@ abstract class OSBackgroundSync {
         try {
             int result = jobScheduler.schedule(jobBuilder.build());
             OneSignal.Log(OneSignal.LOG_LEVEL.INFO, "OSBackgroundSync scheduleSyncServiceAsJob:result: " + result);
-        } catch (NullPointerException e) {
+        } catch (NullPointerException | IllegalStateException e) {
             // Catch for buggy Oppo devices
             // https://github.com/OneSignal/OneSignal-Android-SDK/issues/487
             OneSignal.Log(OneSignal.LOG_LEVEL.ERROR,


### PR DESCRIPTION

<!--- Please put JIRA ticket URL and its title in first line. --->
# [TECH-4703] IllegalStateException when JobSchedulerImpl.schedule

## Summary:
Apps may not schedule more than 100 distinct jobs

## How to Resolve:
### Root Cause:
IllegalStateException Apps may not schedule more than 100 distinct jobs

### Solution:
catch IllegalStateException(just workaround since we don't know why onesignal create distinct job)

## Verification Steps
### Prerequisites:


### Steps:

### Expected Result:
work normally

## Notes(Optional):
<!--- Put some additional information can help verification here, such as:
* Known/unsolved issues in this bug.
* As stated above, what help do you need.
* Before/after comparison screenshots for UI modifications.
* Video(.mp4) or animation(.gif) to demo the process and/or result.
* Previous related PRs if this PR is part of a series.
* Other parts that you want reviewers to pay attention to or to ignore.
-->


[TECH-4703]: https://17media.atlassian.net/browse/TECH-4703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ