### PR TITLE
[APP-33307] access db in main thread when open/dismiss notification

### DIFF
--- a/OneSignalSDK/onesignal/build.gradle
+++ b/OneSignalSDK/onesignal/build.gradle
@@ -51,6 +51,8 @@ dependencies {
     // Required for GoogleApiAvailability
     implementation 'com.google.android.gms:play-services-base:[17.0.0, 17.6.99]'
 
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.3"
+
     // firebase-messaging:18.0.0 is the last version before going to AndroidX
     // firebase-messaging:19.0.0 is the first version using AndroidX
     api 'com.google.firebase:firebase-messaging:[19.0.0, 22.0.99]'

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/BadgeCountUpdater.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/BadgeCountUpdater.java
@@ -49,8 +49,9 @@ class BadgeCountUpdater {
    private static int badgesEnabled = -1;
 
    private static boolean areBadgeSettingsEnabled(Context context) {
-      if (badgesEnabled != -1)
+      if (badgesEnabled != -1) {
          return (badgesEnabled == 1);
+      }
 
       try {
          ApplicationInfo ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
@@ -116,10 +117,6 @@ class BadgeCountUpdater {
       } finally {
          if (null != cursor && !cursor.isClosed()) cursor.close();
       }
-      int notificationCount = cursor.getCount();
-      cursor.close();
-
-      updateCount(notificationCount, context);
    }
 
    static void updateCount(int count, Context context) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/utils/CoroutineExecutor.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/utils/CoroutineExecutor.kt
@@ -1,0 +1,25 @@
+package com.onesignal.utils
+
+import androidx.annotation.AnyThread
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+
+object CoroutineExecutor {
+
+    @JvmStatic
+    @AnyThread
+    fun launchIO(block: suspend CoroutineScope.() -> Unit) = GlobalScope.launch(Dispatchers.IO) {
+        block()
+    }
+
+    // Don't call Thread.sleep in your runnable
+    @JvmStatic
+    @AnyThread
+    fun launchIO(runnable: Runnable) {
+        launchIO {
+            runnable.run()
+        }
+    }
+}


### PR DESCRIPTION
<!--- Please put JIRA ticket URL and its title in first line. --->
# [APP-33307] onesignal NotificationDismissReceiver do DB access in main thread

## Summary:
[APP-33307] onesignal NotificationDismissReceiver do DB access in main thread which could cause ANR

## How to Resolve:
### Root Cause:
1. onesignal NotificationDismissReceiver do DB access in main thread which could cause ANR

### Solution:
1. move db handler into background thread(it could loss dismiss status temporarily, but we don't care)

## Verification Steps
### Prerequisites:
receive notification

### Steps:
open notification or just dismiss(slide left) it

### Expected Result:
access db in background thread, and work normally

## Notes(Optional):
<!--- Put some additional information can help verification here, such as:
* Known/unsolved issues in this bug.
* As stated above, what help do you need.
* Before/after comparison screenshots for UI modifications.
* Video(.mp4) or animation(.gif) to demo the process and/or result.
* Previous related PRs if this PR is part of a series.
* Other parts that you want reviewers to pay attention to or to ignore.
-->


[APP-33307]: https://17media.atlassian.net/browse/APP-33307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
