### PR TITLE
[APP-34007] onesignal access job service timeout

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/utils/CoroutineExecutor.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/utils/CoroutineExecutor.kt
@@ -1,12 +1,14 @@
 package com.onesignal.utils
 
 import androidx.annotation.AnyThread
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
+import java.lang.Runnable
+import java.util.concurrent.Executors
 
 object CoroutineExecutor {
+
+    private val singleThreadDispatcher = Executors.newFixedThreadPool(1).asCoroutineDispatcher()
+    private val singleThreadScope = CoroutineScope(SupervisorJob() + singleThreadDispatcher)
 
     @JvmStatic
     @AnyThread
@@ -22,4 +24,14 @@ object CoroutineExecutor {
             runnable.run()
         }
     }
+
+    // Don't call Thread.sleep in your runnable
+    @JvmStatic
+    @AnyThread
+    fun launchInSingleThread(runnable: Runnable) {
+        singleThreadScope.launch {
+            runnable.run()
+        }
+    }
+
 }


### PR DESCRIPTION

<!--- Please put JIRA ticket URL and its title in first line. --->
# [APP-34007] onesignal access job service timeout

## Summary:
[APP-34007] main thread block when access job service caused ANR

## How to Resolve:
### Root Cause:
main thread block when access remote service caused ANR

### Solution:
move add sync service/fous lost service behavior into background
ps: move to single thread(original in main thread) since we need to prevent it create duplicated job

## Verification Steps
### Prerequisites:
monitor streamer

### Steps:
streamer start to streaming

### Expected Result:
work normally (could receive notification)

## Notes(Optional):
<!--- Put some additional information can help verification here, such as:
* Known/unsolved issues in this bug.
* As stated above, what help do you need.
* Before/after comparison screenshots for UI modifications.
* Video(.mp4) or animation(.gif) to demo the process and/or result.
* Previous related PRs if this PR is part of a series.
* Other parts that you want reviewers to pay attention to or to ignore.
-->


[APP-34007]: https://17media.atlassian.net/browse/APP-34007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-34007]: https://17media.atlassian.net/browse/APP-34007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ