### PR TITLE
Add github action to trigger deploy when there's new tag been created

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,7 +3,7 @@ name: Android CI
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - 'm*.*.*'
 
 jobs:
   build:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,4 +24,7 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build
       - name: Deploy to jfrog
+        env:
+          jfrogUser: ${{ secrets.jfrog_user }}
+          jfrogToken: ${{ secrets.jfrog_token }}
         run: ./gradlew onesignal:assembleRelease onesignal:artifactoryPublish

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,27 @@
+name: Android CI
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew build
+      - name: Deploy to jfrog
+        run: ./gradlew onesignal:assembleRelease onesignal:artifactoryPublish

--- a/OneSignalSDK/onesignal/maven-publish.gradle
+++ b/OneSignalSDK/onesignal/maven-publish.gradle
@@ -1,10 +1,8 @@
 apply plugin: "com.jfrog.artifactory"
 apply plugin: "maven-publish"
 
-Properties properties = new Properties()
-properties.load(project.rootProject.file('local.properties').newDataInputStream()) // load local.properties
-def JFROG_USER_NAME = properties.getProperty('jfrog.username') // read property from local.properties
-def JFROG_TOKEN = properties.getProperty('jfrog.token')
+def JFROG_USER_NAME =  System.getenv("jfrogUser")
+def JFROG_TOKEN = System.getenv("jfrogToken")
 
 def REPO_KEY = "live17" // should be "live17"
 def MAVEN_LOCAL_PATH = "https://live17.jfrog.io/artifactory/"  // should be "https://live17.jfrog.io/artifactory/"


### PR DESCRIPTION
We'll add .github/workflows/android.yml to trigger github action to deploy to jfrog.

The user name and token will now be encrypt in repository secret store in github only, so client have no right to trigger the build by themself.

Currently the secret is wrong, will test it after this is merged and nothing is leak during the build. And then we'll update the correct secret.