### PR TITLE
Update path of gradlew

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,11 +20,11 @@ jobs:
           cache: gradle
 
       - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+        run: chmod +x ./OneSignalSDK/gradlew
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./OneSignalSDK/gradlew build
       - name: Deploy to jfrog
         env:
           jfrogUser: ${{ secrets.jfrog_user }}
           jfrogToken: ${{ secrets.jfrog_token }}
-        run: ./gradlew onesignal:assembleRelease onesignal:artifactoryPublish
+        run: ./OneSignalSDK/gradlew onesignal:assembleRelease onesignal:artifactoryPublish


### PR DESCRIPTION
Given the current project structure, we should use ./OneSignalSDK/gradlew instead of gradlew directly

Reference:
https://github.com/17media/OneSignal-Android-SDK/runs/6074305662?check_suite_focus=true